### PR TITLE
Fix: SponsorBlock video ID incorrect

### DIFF
--- a/NUXT/components/Player/index.vue
+++ b/NUXT/components/Player/index.vue
@@ -328,7 +328,7 @@ export default {
     this.vidSrc = this.sources[this.sources.length - 1].url;
     let vid = this.$refs.player;
 
-    this.$youtube.getSponsorBlock(this.vidSrc, (data) => {
+    this.$youtube.getSponsorBlock(this.video.id, (data) => {
       console.log("sbreturn", data);
       if (Array.isArray(data)) {
         this.blocks = data;


### PR DESCRIPTION
The URL previously being passed to SponsorBlock API was the video src URL, not the video ID as it should be.

[Screenshot](https://photos.app.goo.gl/13n64TJgk7EH3VTf6)