### PR TITLE
Disable Server Side Rendering for Faster Builds

### DIFF
--- a/NUXT/nuxt.config.js
+++ b/NUXT/nuxt.config.js
@@ -53,6 +53,8 @@ export default {
   buildModules: ["@nuxtjs/vuetify"],
   modules: [],
 
+  ssr: false,
+
   vuetify: {
     customVariables: ["~/assets/variables.scss"],
     treeShake: true,


### PR DESCRIPTION
Disable the Server Side rendering option in nuxt config to disable building server and thus faster builds

Comparison:

With SSR:
![Normal](https://user-images.githubusercontent.com/57246976/173526376-5aca9d6b-36a7-4e6e-a048-60ddd9bcf5f2.png)

Without SSR:
![Without SSR](https://user-images.githubusercontent.com/57246976/173526387-702d2949-fd27-417d-bdba-4b12a299ab23.png)

