### PR TITLE
Improve Dutch translations

### DIFF
--- a/NUXT/plugins/languages/dutch.js
+++ b/NUXT/plugins/languages/dutch.js
@@ -15,14 +15,14 @@ module.exports = {
     settings: {
       general: "Algemeen",
       theme: "Thema",
-      player: "Video Player",
-      uitweaker: "Gebruikers Interface",
-      startupoptions: "Opstart Opties",
+      player: "Videospeler",
+      uitweaker: "Gebruikersinterface",
+      startupoptions: "Opstartopties",
       plugins: "Plugins",
       updates: "Updates",
-      logs: "Logs",
+      logs: "Logboeken",
       about: "Over",
-      devmode: "Register Bewerken"
+      devmode: "Register bewerken"
     },
   
     mods: {
@@ -35,15 +35,15 @@ module.exports = {
         custom: "Aangepast",
         dark: "Donker",
         black: "Zwart",
-        darkmode: "Donkere Modus",
+        darkmode: "Donkere modus",
         darkmodetagline: "Bravo Six, Going Dark."
       },
       tweaks: {
-        fullscreen: "Volledig Scherm",
-        navbarblur: "Vervaging Navigatiebalk",
-        roundedcorners: "Afgeronde Hoeken",
-        roundthumbnails: "Ronde Hoeken In Video Afbeelding",
-        roundwatchpagecomponents: "Ronde Hoeken In Video Speler Componenten",
+        fullscreen: "Volledig scherm",
+        navbarblur: "Vervaging navigatiebalk",
+        roundedcorners: "Afgeronde hoeken",
+        roundthumbnails: "Ronde hoeken in miniatuurafbeelding",
+        roundwatchpagecomponents: "Ronde hoeken in videospeler",
         radius: "Radius"
       },
       startup: {
@@ -59,9 +59,9 @@ module.exports = {
         more: "Meer"
       },
       about: {
-        appinformation: "App Informatie",
-        appversion: "App Versie",
-        deviceinformation: "Apparaat Informatie",
+        appinformation: "Applicatieinformatie",
+        appversion: "Applicatieversie",
+        deviceinformation: "Apparaatinformatie",
         platform: "Platform",
         os: "Besturingssysteem",
         model: "Model",
@@ -76,7 +76,7 @@ module.exports = {
       welcome: "Welkom bij VueTube",
       tagline: "De toekomst van videostreaming",
       next: "Volgende",
-      updated: "VueTube is Geupdate!",
+      updated: "VueTube is geüpdatet!",
       awesome: "Geweldig!"
     }
   


### PR DESCRIPTION
Improved translation (uppercase where it shouldn't be used, grammar, use of existing Dutch words instead of an anglicism)