### PR TITLE
Add shortcut to app translations in Readme

### DIFF
--- a/readme.es.md
+++ b/readme.es.md
@@ -86,6 +86,8 @@ Bueno, esto ha estado en el servidor de Discord de Return YouTube Dislike durant
 
 Por favor, lee en nuestro sitio web cómo hacerlo: www.vuetube.app/contributing
 
+Si quieres traducir la app, [haz clic aquí](/NUXT/plugins/languages) y lee cómo hacerlo
+
 ## Colaboradores
 
 <a href="https://github.com/VueTubeApp/VueTube/graphs/contributors">

--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,8 @@ Well this has been thrown around on the Return Youtube Dislike discord server fo
 
 Please read our website on how to do so: www.vuetube.app/contributing
 
+If you want to translate the app, [click here](/NUXT/plugins/languages) and read how to do it
+
 ## Contributors
 
 <a href="https://github.com/VueTubeApp/VueTube/graphs/contributors">


### PR DESCRIPTION
I added, in the contributing section, a link to go directly to app translations folder for people who want to translate the app, because it’s hard to find. This change is only implemented in Spanish and English Readme.