### PR TITLE
Add link to VueTube official website in Github issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,3 +6,6 @@ contact_links:
   - name: 💬 Telegram
     url: https://t.me/vuetube
     about: Join the Telegram group to chat and ask questions
+  - name: 💬 VueTube website
+    url: https://t.me/vuetube
+    about: For example, to check FAQ before asking frecuently asked questions (wait... then they won't be frequently asked questions?)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,5 +7,5 @@ contact_links:
     url: https://t.me/vuetube
     about: Join the Telegram group to chat and ask questions
   - name: 💬 VueTube website
-    url: https://t.me/vuetube
+    url: https://vuetube.app/
     about: For example, to check FAQ before asking frecuently asked questions (wait... then they won't be frequently asked questions?)


### PR DESCRIPTION
Add a link to VueTube website in Github issues opening page, for humans can check the documentation and read the FAQ before generating issues.
Also it contains a joke that I saw on the Discord server about how FAQ stop being frecuently asked questions if they aren't asked because they are in the FAQ.
If you want to be serious and don't make obvious you are teenagers like me with a broken sense humour, tell me.