### PR TITLE
Edited some French translation

### DIFF
--- a/NUXT/plugins/languages/french-fr.js
+++ b/NUXT/plugins/languages/french-fr.js
@@ -21,7 +21,7 @@ module.exports = {
     player: "Lecteur vidéo",
     uitweaker: "Personnalisation de l'interface",
     startupoptions: "Options de démarrage",
-    plugins: "Plug-ins",
+    plugins: "Plugins",
     updates: "Mises à jour",
     logs: "Journaux",
     about: "À propos",
@@ -55,7 +55,7 @@ module.exports = {
     updates: {
       install: "Installer",
       view: "Voir",
-      latest: "Version plus récente",
+      latest: "Dernière MÀJ",
       installed: "Version installée",
     },
     logs: {
@@ -84,9 +84,10 @@ module.exports = {
     langsetup: "Commençons par sélectionner une langue !",
     featuresetup: "Sélectionnons des fonctionnalités !",
     enableryd:
-      "Activer Return YouTube Dislike (Retourner les Dislikes de YouTube)",
+      "Activer les dislikes",
     enablespb: "Activer SponsorBlock",
     thanks: "Merci d'utiliser VueTube",
-    enjoy: "Nous ésperons que vous apprécierez votre éxperience ! ",
+    enjoy: "Nous espérons que vous apprécierez votre expérience ! ",
+    packageinstaller: "Sélectionne un paquet à télécharger"
   },
 };


### PR DESCRIPTION
Btw in the settings page, the first letter of every word is uppercase. For English it can be understandable for sentences like "Startup Options", but in other languages (including French), it can be weird to have "Options De Démarrage" (a little too many letters that are uppercase). I think VueTube should not apply this to every language.