### PR TITLE
Bug fixing, i guess

### DIFF
--- a/NUXT/pages/settings.vue
+++ b/NUXT/pages/settings.vue
@@ -129,7 +129,7 @@ export default {
     this.settingsItems[4].name = this.$lang("settings").startupoptions;
     this.settingsItems[5].name = this.$lang("settings").plugins;
     this.settingsItems[6].name = this.$lang("settings").updates;
-    this.settingsItems[8].name = this.$lang("settings").about;
+    this.settingsItems[7].name = this.$lang("settings").about;
     this.devmodebuttonname = this.$lang("settings").devmode;
 
     this.devmode = localStorage.getItem("devmode");

--- a/NUXT/plugins/languages/english.js
+++ b/NUXT/plugins/languages/english.js
@@ -27,7 +27,7 @@ module.exports = {
     updates: "Updates",
     logs: "Logs",
     about: "About",
-    devmode: "Registry Editor",
+    devmode: "Developer mode",
   },
 
   mods: {

--- a/NUXT/plugins/languages/spanish.js
+++ b/NUXT/plugins/languages/spanish.js
@@ -27,7 +27,7 @@ module.exports = {
     updates: "Actualizaciones",
     logs: "Registros",
     about: "Acerca de",
-    devmode: "Editor de registros",
+    devmode: "Modo de desarrollador",
   },
 
   mods: {


### PR DESCRIPTION
I am now a shitty developer instead of a non developer :D
This is supposed (just supposed) to fix "About" in Settings not translating.
I also updated English and Spanish JS to change "Registry Editor" to "Developer Mode"
I dont know how to make the dev button show the matching translation