### PR TITLE
Update page improvement

### DIFF
--- a/NUXT/pages/mods/updates.vue
+++ b/NUXT/pages/mods/updates.vue
@@ -4,7 +4,7 @@
     
     <div v-if="status == 'checking'">
       <h1>{{ lang.checking }}</h1>
-      <div>{{ lang.installed }}: {{ installedVersion }}</div>
+      <div>{{ lang.installed }}: {{ version.substring(0, 7) || "Unknown" }}  ({{ release }})</div>
       <center>
         <v-progress-circular indeterminate color="primary" size="75" style="padding-top: 10em;" />
       </center>
@@ -22,7 +22,7 @@
     <div v-if="status == 'available'">
       <h1 v-if="!downloading">{{ lang.available }}</h1>
       <h1 v-if="downloading">{{ lang.updating }}</h1>
-      <div>{{ lang.installed }}: {{ installedVersion }}</div>
+      <div>{{ lang.installed }}: {{ version.substring(0, 7) || "Unknown" }}  ({{ release }})</div>
       <div>{{ lang.latest }}: {{ latestVersion.tag_name }}</div>
 
       <div style="margin-top: 1em; color: #999;">


### PR DESCRIPTION
When you're using an Unstable version from Actions, update page displays this:

Installed version:
407348a7e0c226366c3a2d6323651f700f0018...
Latest version; 0.4.2

The "installed version" is too long and it doesn't even fit the screen.
With my change, it displays version name like in About page, showing the channel tag and just a few characters.

Installed version: 407348a (Unstable)
Latest version: 0.4.2


I have not tested this in an app build and I'm a extremely basic developer, so it may be wrong. Please check it before merging.
