### PR TITLE
Add a missing translation field + Improve button in Backup

### DIFF
--- a/NUXT/pages/mods/general.vue
+++ b/NUXT/pages/mods/general.vue
@@ -22,10 +22,10 @@
     >
       <v-card-title>{{ lang.backup }}</v-card-title>
       <v-card-text>
-        <p>Backup or restore your application settings</p>
+        <p>{{ lang.backupinfo }}</p>
       </v-card-text>
       <v-card-actions>
-        <v-btn rounded color="primary darken-2" @click="registryBackup">{{ lang.backup }}</v-btn>
+        <v-btn rounded depressed class="background--text ml-2" color="primary" @click="registryBackup">{{ lang.backup }}</v-btn>
         <v-btn rounded @click="registryRestore">{{ lang.restore }}</v-btn>
       </v-card-actions>
     </v-card>

--- a/NUXT/plugins/languages/english.js
+++ b/NUXT/plugins/languages/english.js
@@ -54,6 +54,7 @@ module.exports = {
     general: {
       language: "Language",
       backup: "Backup",
+      backupinfo: "Backup or restore your application settings",
       restore: "Restore"
     },
     theme: {

--- a/NUXT/plugins/languages/spanish.js
+++ b/NUXT/plugins/languages/spanish.js
@@ -53,6 +53,7 @@ pages: {
     general: {
       language: "Idioma",
       backup: "Copia de seguridad",
+      backupinfo: "Haz una copia de seguridad de tus ajustes o restáuralos",
       restore: "Restaurar"
     },
     theme: {


### PR DESCRIPTION
"Backup or restore your application settings" text now can be translated (implemented in English.js and Spanish.js) and button is more readable, just like in Update page.