### PR TITLE
Remove code duplication for thumbnails loading

### DIFF
--- a/NUXT/components/Player/index.vue
+++ b/NUXT/components/Player/index.vue
@@ -54,7 +54,7 @@
               }rem 0rem 0rem !important`
             : '0',
       }"
-      :poster="$youtube.getThumbnail($route.query.v, 'max', [])"
+      :poster="getThumbnail($route.query.v)"
       @loadedmetadata="checkDimensions()"
       @click="controlsHandler()"
     />
@@ -352,6 +352,7 @@ import progressbar from "~/components/Player/progressbar.vue";
 import sponsorblock from "~/components/Player/sponsorblock.vue";
 
 import backType from "~/plugins/classes/backType";
+import Thumbnail from "~/plugins/thumbnail";
 
 export default {
   components: {
@@ -622,6 +623,11 @@ export default {
       this.$refs.player.currentTime = time;
       this.$refs.player.playbackRate = speed;
       this.$refs.audio.playbackRate = speed;
+    },
+    getThumbnail(query) {
+      const thumbnail = new Thumbnail();
+
+      return thumbnail.getThumbnail(query, "max", []);
     },
     checkDimensions() {
       if (this.$refs.player.videoHeight > this.$refs.player.videoWidth) {

--- a/NUXT/plugins/innertube.js
+++ b/NUXT/plugins/innertube.js
@@ -262,20 +262,6 @@ class Innertube {
     });
   }
 
-  // Static methods
-
-  static getThumbnail(id, resolution) {
-    if (resolution == "max") {
-      const url = `https://img.youtube.com/vi/${id}/maxresdefault.jpg`;
-      let img = new Image();
-      img.src = url;
-      img.onload = function () {
-        if (img.height !== 120) return url;
-      };
-    }
-    return `https://img.youtube.com/vi/${id}/mqdefault.jpg`;
-  }
-
   // Simple Wrappers
   async getRecommendationsAsync() {
     const rec = await this.browseAsync("recommendations");

--- a/NUXT/plugins/thumbnail.js
+++ b/NUXT/plugins/thumbnail.js
@@ -1,0 +1,17 @@
+class Thumbnail {
+  getThumbnail(id, resolution, backupThumbnail) {
+    if (resolution == "max") {
+      const url = `https://img.youtube.com/vi/${id}/maxresdefault.jpg`;
+      let img = new Image();
+      img.src = url;
+      img.onload = function () {
+        if (img.height !== 120) return url;
+      };
+    }
+    if (backupThumbnail[backupThumbnail.length - 1])
+      return backupThumbnail[backupThumbnail.length - 1].url;
+    else return `https://img.youtube.com/vi/${id}/mqdefault.jpg`;
+  }
+}
+
+export default Thumbnail;

--- a/NUXT/plugins/youtube.js
+++ b/NUXT/plugins/youtube.js
@@ -91,30 +91,14 @@ const innertubeModule = {
   async getVid(id) {
     try {
       return await InnertubeAPI.VidInfoAsync(id);
-    } catch (error) {
-    }
-  },
-
-  getThumbnail(id, resolution, backupThumbnail) {
-    if (resolution == "max") {
-      const url = `https://img.youtube.com/vi/${id}/maxresdefault.jpg`;
-      let img = new Image();
-      img.src = url;
-      img.onload = function () {
-        if (img.height !== 120) return url;
-      };
-    }
-    if (backupThumbnail[backupThumbnail.length - 1])
-      return backupThumbnail[backupThumbnail.length - 1].url;
-    else return `https://img.youtube.com/vi/${id}/mqdefault.jpg`;
+    } catch (error) {}
   },
 
   async getChannel(url) {
     try {
       const response = await InnertubeAPI.getChannelAsync(url);
       return response.data;
-    } catch (error) {
-    }
+    } catch (error) {}
   },
 
   // It just works™
@@ -177,8 +161,7 @@ const innertubeModule = {
     try {
       const response = await InnertubeAPI.getSearchAsync(query);
       return response.contents.sectionListRenderer;
-    } catch (err) {
-    }
+    } catch (err) {}
   },
 
   async saveApiStats(query, url) {


### PR DESCRIPTION
This PR is aimed to drop duplicated function `getThumbnails` by extracting it to a separate `Thumbnail` class.