### PR TITLE
feat: 🕒 added sharing video link with timestamp (#72)

### DIFF
--- a/NUXT/pages/watch.vue
+++ b/NUXT/pages/watch.vue
@@ -379,7 +379,12 @@ export default {
       await Share.share({
         title: this.video.title,
         text: this.video.title,
-        url: "https://youtu.be/" + this.$route.query.v,
+        url:
+          "https://youtu.be/" +
+          this.$route.query.v +
+          "?t=" +
+          Math.round(this.$refs.player.getPlayer().currentTime) +
+          "s",
         dialogTitle: "Share video",
       });
     },


### PR DESCRIPTION
Implemented the feature to share the video link with timestamp by getting the player current time and adding the time to the url as query parameter.