### PR TITLE
Fix video title colour in full screen mode

### DIFF
--- a/NUXT/components/Player/index.vue
+++ b/NUXT/components/Player/index.vue
@@ -155,7 +155,7 @@
       >
         <minimize />
         <div v-if="isFullscreen" class="pt-2" @click.self="controlsHandler()">
-          <h4>{{ video.title }}</h4>
+          <h4 style="color: #ffffff">{{ video.title }}</h4>
           <div style="color: #aaa; font-size: 0.75rem">
             {{ video.channelName }}
           </div>


### PR DESCRIPTION
Sets video title colour to white in full screen mode.
Fixes issue https://github.com/VueTubeApp/VueTube/issues/628